### PR TITLE
Improve Load Times on Debug builds

### DIFF
--- a/src/Helpers/EntityUtils.cpp
+++ b/src/Helpers/EntityUtils.cpp
@@ -33,7 +33,9 @@ std::vector<ZEntityRef> Utils::ZEntityFinder::Find(const size_t p_nMaxResults) c
         return s_aFoundEntities;
     }
 
-    std::queue<std::pair<ZEntityBlueprintFactoryBase*, ZEntityRef>> s_qNodeQueue;
+    std::vector<std::pair<ZEntityBlueprintFactoryBase*, ZEntityRef>> s_aNodeQueue;
+    size_t s_nCurrentQueueIndex = 0;
+
     for (const auto& s_Brick : s_pSceneCtx->m_aLoadedBricks)
     {
         const auto s_Entity = s_Brick.m_EntityRef;
@@ -48,13 +50,13 @@ std::vector<ZEntityRef> Utils::ZEntityFinder::Find(const size_t p_nMaxResults) c
             continue;
         }
 
-        s_qNodeQueue.emplace(s_pBpFactory, s_Entity);
+        s_aNodeQueue.emplace_back(s_pBpFactory, s_Entity);
     }
 
-    while (!s_qNodeQueue.empty())
+    while (s_nCurrentQueueIndex < s_aNodeQueue.size())
     {
-        auto [s_pCurrentFactory, s_CurrentRoot] = s_qNodeQueue.front();
-        s_qNodeQueue.pop();
+        auto [s_pCurrentFactory, s_CurrentRoot] = s_aNodeQueue[s_nCurrentQueueIndex];
+        s_nCurrentQueueIndex++;
 
         // go through each sub-entity
         const auto s_SubEntityCount = s_pCurrentFactory->GetSubEntitiesCount();
@@ -71,7 +73,7 @@ std::vector<ZEntityRef> Utils::ZEntityFinder::Find(const size_t p_nMaxResults) c
             // if the sub-entity has a factory with more sub-entities, add it to the queue.
             if (s_pSubEntityFactory && s_pSubEntityFactory->GetSubEntitiesCount() > 0)
             {
-                s_qNodeQueue.emplace(s_pSubEntityFactory, s_SubEntity);
+                s_aNodeQueue.emplace_back(s_pSubEntityFactory, s_SubEntity);
             }
 
             // add if matches

--- a/src/Helpers/EntityUtils.cpp
+++ b/src/Helpers/EntityUtils.cpp
@@ -135,7 +135,7 @@ bool Utils::ZEntityFinder::Evaluate(const ZEntityRef& p_rEntity, ZEntityBlueprin
     return true;
 }
 
-std::string Utils::GetEntityName(const ZEntityRef& p_Entity, ZEntityBlueprintFactoryBase* p_pFactory, int p_nSubIndex)
+std::string_view Utils::GetEntityName(const ZEntityRef& p_Entity, ZEntityBlueprintFactoryBase* p_pFactory, int p_nSubIndex)
 {
     if (!p_Entity)
     {
@@ -188,7 +188,7 @@ std::string Utils::GetEntityName(const ZEntityRef& p_Entity, ZEntityBlueprintFac
     return "";
 }
 
-std::string Utils::GetEntityTypeName(const ZEntityRef& p_Entity)
+std::string_view Utils::GetEntityTypeName(const ZEntityRef& p_Entity)
 {
     if (!p_Entity)
     {

--- a/src/Helpers/EntityUtils.h
+++ b/src/Helpers/EntityUtils.h
@@ -7,6 +7,7 @@
 
 #include <vector>
 #include <string>
+#include <string_view>
 #include <optional>
 
 #define TAG "[EntityUtils] "
@@ -97,13 +98,13 @@ namespace Utils
      * @param p_pFactory Entity Blueprint pointer. If nullptr, attempt to find from entity ref.
      * @param p_nSubIndex Entity sub-index in blueprint. If -1, attempt to find from entity ref.
      */
-    std::string GetEntityName(const ZEntityRef& p_Entity, ZEntityBlueprintFactoryBase* p_pFactory = nullptr, int p_nSubIndex = -1);
+    std::string_view GetEntityName(const ZEntityRef& p_Entity, ZEntityBlueprintFactoryBase* p_pFactory = nullptr, int p_nSubIndex = -1);
 
     /**
      * Attempt to get the (primary) type name of an entity.
      * @param p_Entity Entity reference.
      */
-    std::string GetEntityTypeName(const ZEntityRef& p_Entity);
+    std::string_view GetEntityTypeName(const ZEntityRef& p_Entity);
 
     /**
      * Attempt to get the blueprint factory of an entity, even if it's a sub-entity.


### PR DESCRIPTION
<!-- 
Please provide a brief summary of the changes in this pull request. 
Include any relevant context, screenshots, notes.
If this PR is related to an issue (active or not), please reference it here.
-->

adds some optimizations to EntityFinder to speed up load time.
this mainly targets debug builds, bc i'm kinda sick of waiting for it to load.
on release builds, only a slight improvement is present.


### Benchmark

| Scenario | Approx. Load Time\* |
|-|-|
mod release 1.2.2 | 48s
mod disabled in SDK | 38s
EntityFinder::Find stubbed (return empty list) | 41s
std::string_view | 44s
std::string_view + no std::queue | 41s


> \* Tested on my machine, with debug builds of SDK and the mod, but no debugger attached. measuring from game window opening to in-game.


## Checklist

- [x] I consent to automatic PR review by GitHub Copilot. <!-- This consent is optional; uncheck to opt out for this PR. -->
- [ ] I added attributon (if applicable)
- [ ] I updated documentation (if applicable)
