### PR TITLE
Add Multiple UI / HUD Effects

### DIFF
--- a/src/Effects/Base/Companion/ZCompanionModDependentEffectBase.cpp
+++ b/src/Effects/Base/Companion/ZCompanionModDependentEffectBase.cpp
@@ -2,9 +2,13 @@
 
 bool ZCompanionModDependentEffectBase::Available() const
 {
+    return IChaosEffect::Available() && HasCompanionMod();
+}
+
+bool ZCompanionModDependentEffectBase::HasCompanionMod(const CompanionModUtil::SVersion p_MinimumVersion) const
+{
     const auto s_Metadata = CompanionModUtil::LoadCompanionModInfo(false);
 
-    return IChaosEffect::Available()
-           && s_Metadata.m_bPresent
+    return s_Metadata.m_bPresent
            && s_Metadata.m_Version >= m_MinimumVersion;
 }

--- a/src/Effects/Base/Companion/ZCompanionModDependentEffectBase.cpp
+++ b/src/Effects/Base/Companion/ZCompanionModDependentEffectBase.cpp
@@ -10,5 +10,5 @@ bool ZCompanionModDependentEffectBase::HasCompanionMod(const CompanionModUtil::S
     const auto s_Metadata = CompanionModUtil::LoadCompanionModInfo(false);
 
     return s_Metadata.m_bPresent
-           && s_Metadata.m_Version >= m_MinimumVersion;
+           && s_Metadata.m_Version >= p_MinimumVersion;
 }

--- a/src/Effects/Base/Companion/ZCompanionModDependentEffectBase.h
+++ b/src/Effects/Base/Companion/ZCompanionModDependentEffectBase.h
@@ -12,6 +12,20 @@ class ZCompanionModDependentEffectBase : public virtual IChaosEffect
 
     bool Available() const override;
 
+  protected:
+    /**
+     * manually checks if a certain version of the companion mod is available.
+     * this is for effects that generally work in older versions of the companion, but have additional features with newer versions.
+     * this does NOT affect the availability status of the effect!
+     * @param p_MinimumVersion The minimum version of the companion mod.
+     * @return is at least that version installed?
+     */
+    bool HasCompanionMod(const CompanionModUtil::SVersion p_MinimumVersion) const;
+    inline bool HasCompanionMod() const
+    {
+        return HasCompanionMod(m_MinimumVersion);
+    }
+
   private:
     CompanionModUtil::SVersion m_MinimumVersion;
 };

--- a/src/Effects/Base/Companion/ZHUDImageVideoViewEffectBase.cpp
+++ b/src/Effects/Base/Companion/ZHUDImageVideoViewEffectBase.cpp
@@ -2,38 +2,28 @@
 
 #include <imgui.h>
 
-#include "Helpers/Utils.h"
-#include "Helpers/EntityUtils.h"
-#include "Entity/EntityIds.h"
-
-void ZHUDImageVideoViewEffectBase::OnEnterScene()
+void ZHUDImageVideoViewEffectBase::LoadResources()
 {
-    m_rImageVideoView = Utils::ZEntityFinder()
-                            .EntityID(EntityId::CompanionMod::GameEssentials::HUDImageVideoView)
-                            .FindFirst();
+    m_pViewSpawner = ZTemplateEntitySpawner::Create<"[assembly:/_pro/chaosmod/hud_image_video_view.entitytemplate].pc_entitytype">();
 }
 
 void ZHUDImageVideoViewEffectBase::OnClearScene()
 {
-    m_rImageVideoView = {};
+    m_rLastSpawnedViewEntity = {};
+    m_pViewSpawner = nullptr;
 }
 
 bool ZHUDImageVideoViewEffectBase::Available() const
 {
     return ZCompanionModDependentEffectBase::Available()
-           && m_rImageVideoView;
-}
-
-bool ZHUDImageVideoViewEffectBase::IsCompatibleWith(const IChaosEffect* p_pOther) const
-{
-    return ZCompanionModDependentEffectBase::IsCompatibleWith(p_pOther)
-           // only one video / image view is available, so only one effect at a time
-           && !Utils::IsInstanceOf<ZHUDImageVideoViewEffectBase>(p_pOther);
+           && m_pViewSpawner && m_pViewSpawner->IsAvailable();
 }
 
 void ZHUDImageVideoViewEffectBase::OnDrawDebugUI()
 {
-    auto s_View = GetImageAndVideoViewBinding();
+    ImGui::TextUnformatted(fmt::format("Prop: {}", m_pViewSpawner->ToString()).c_str());
+
+    auto s_View = SImageVideoViewEntityBinding(m_rLastSpawnedViewEntity);
     if (!s_View)
     {
         return;
@@ -117,7 +107,7 @@ void ZHUDImageVideoViewEffectBase::OnDrawDebugUI()
     }
 }
 
-SImageVideoViewEntityBinding ZHUDImageVideoViewEffectBase::GetImageAndVideoViewBinding() const
+SImageVideoViewEntityBinding ZHUDImageVideoViewEffectBase::SpawnImageAndVideoView() const
 {
-    return SImageVideoViewEntityBinding(m_rImageVideoView);
+    return SImageVideoViewEntityBinding(m_pViewSpawner->Spawn());
 }

--- a/src/Effects/Base/Companion/ZHUDImageVideoViewEffectBase.cpp
+++ b/src/Effects/Base/Companion/ZHUDImageVideoViewEffectBase.cpp
@@ -107,7 +107,8 @@ void ZHUDImageVideoViewEffectBase::OnDrawDebugUI()
     }
 }
 
-SImageVideoViewEntityBinding ZHUDImageVideoViewEffectBase::SpawnImageAndVideoView() const
+SImageVideoViewEntityBinding ZHUDImageVideoViewEffectBase::SpawnImageAndVideoView()
 {
-    return SImageVideoViewEntityBinding(m_pViewSpawner->Spawn());
+    m_rLastSpawnedViewEntity = m_pViewSpawner->Spawn();
+    return SImageVideoViewEntityBinding(m_rLastSpawnedViewEntity);
 }

--- a/src/Effects/Base/Companion/ZHUDImageVideoViewEffectBase.cpp
+++ b/src/Effects/Base/Companion/ZHUDImageVideoViewEffectBase.cpp
@@ -1,0 +1,123 @@
+#include "ZHUDImageVideoViewEffectBase.h"
+
+#include <imgui.h>
+
+#include "Helpers/Utils.h"
+#include "Helpers/EntityUtils.h"
+#include "Entity/EntityIds.h"
+
+void ZHUDImageVideoViewEffectBase::OnEnterScene()
+{
+    m_rImageVideoView = Utils::ZEntityFinder()
+                            .EntityID(EntityId::CompanionMod::GameEssentials::HUDImageVideoView)
+                            .FindFirst();
+}
+
+void ZHUDImageVideoViewEffectBase::OnClearScene()
+{
+    m_rImageVideoView = {};
+}
+
+bool ZHUDImageVideoViewEffectBase::Available() const
+{
+    return ZCompanionModDependentEffectBase::Available()
+           && m_rImageVideoView;
+}
+
+bool ZHUDImageVideoViewEffectBase::IsCompatibleWith(const IChaosEffect* p_pOther) const
+{
+    return ZCompanionModDependentEffectBase::IsCompatibleWith(p_pOther)
+           // only one video / image view is available, so only one effect at a time
+           && !Utils::IsInstanceOf<ZHUDImageVideoViewEffectBase>(p_pOther);
+}
+
+void ZHUDImageVideoViewEffectBase::OnDrawDebugUI()
+{
+    auto s_View = GetImageAndVideoViewBinding();
+    if (!s_View)
+    {
+        return;
+    }
+
+    if (auto s_voPositionOffset = s_View.m_vPositionOffset; s_voPositionOffset.has_value())
+    {
+        auto s_vPositionOffset = s_voPositionOffset.value();
+        if (ImGui::DragFloat3("Position Offset", &s_vPositionOffset.x, 10.f))
+        {
+            s_View.m_vPositionOffset = s_vPositionOffset;
+        }
+    }
+    else
+    {
+        ImGui::TextUnformatted("Position Offset: N/A");
+    }
+
+    if (auto s_voSize = s_View.m_vSize; s_voSize.has_value())
+    {
+        auto s_vSize = s_voSize.value();
+        if (ImGui::DragFloat2("Size", &s_vSize.x, 10.f))
+        {
+            s_View.m_vSize = s_vSize;
+        }
+    }
+    else
+    {
+        ImGui::TextUnformatted("Size: N/A");
+    }
+
+    if (auto s_voRotation = s_View.m_vRotation; s_voRotation.has_value())
+    {
+        auto s_vRotation = s_voRotation.value();
+        if (ImGui::DragFloat3("Rotation", &s_vRotation.x, 1.f))
+        {
+            s_View.m_vRotation = s_vRotation;
+        }
+    }
+    else
+    {
+        ImGui::TextUnformatted("Rotation: N/A");
+    }
+
+    /*
+    if (auto s_boVideoVolumeOn = s_View.m_bVideoVolumeOn; s_boVideoVolumeOn.has_value())
+    {
+        auto s_bVideoVolumeOn = s_boVideoVolumeOn.value();
+        if (ImGui::Checkbox("Video Volume On", &s_bVideoVolumeOn))
+        {
+            s_View.m_bVideoVolumeOn = s_bVideoVolumeOn;
+        }
+    }
+    else
+    {
+        ImGui::TextUnformatted("Video Volume On: N/A");
+    }
+    */
+
+    if (auto s_boVideoLoop = s_View.m_bVideoLoop; s_boVideoLoop.has_value())
+    {
+        auto s_bVideoLoop = s_boVideoLoop.value();
+        if (ImGui::Checkbox("Video Loop", &s_bVideoLoop))
+        {
+            s_View.m_bVideoLoop = s_bVideoLoop;
+        }
+    }
+    else
+    {
+        ImGui::TextUnformatted("Video Loop: N/A");
+    }
+
+    if (ImGui::Button("PlayVideo"))
+    {
+        s_View.PlayVideo();
+    }
+
+    if (ImGui::Button("StopVideo"))
+    {
+        s_View.StopVideo();
+    }
+}
+
+SImageVideoViewEntityBinding ZHUDImageVideoViewEffectBase::GetImageAndVideoViewBinding() const
+{
+    return SImageVideoViewEntityBinding(m_rImageVideoView);
+}

--- a/src/Effects/Base/Companion/ZHUDImageVideoViewEffectBase.h
+++ b/src/Effects/Base/Companion/ZHUDImageVideoViewEffectBase.h
@@ -1,11 +1,16 @@
 #pragma once
 #include "Effects/Base/Companion/ZCompanionModDependentEffectBase.h"
 
+#include "Helpers/ZTemplateEntitySpawner.h"
+
 #include "Entity/Bindings/SImageVideoViewEntityBinding.h"
 
 /**
  * Base class for accessing HUD Image / Video view added by companion mod.
  * Note that you'll have to handle loading of the image / video resource yourself (via ZResourceProvider).
+ * Use of non-loaded resources (or ones not contained in chunk0) may crash the game.
+ * Also note that, at a maximum 6 videos can be played via this (across ALL effects).
+ * For images, there seems to be no such limit.
  */
 class ZHUDImageVideoViewEffectBase : public virtual ZCompanionModDependentEffectBase
 {
@@ -15,16 +20,17 @@ class ZHUDImageVideoViewEffectBase : public virtual ZCompanionModDependentEffect
     {
     }
 
-    void OnEnterScene() override;
+    void LoadResources() override;
     void OnClearScene() override;
     bool Available() const override;
-    bool IsCompatibleWith(const IChaosEffect* p_pOther) const override;
 
     void OnDrawDebugUI() override;
 
   protected:
-    SImageVideoViewEntityBinding GetImageAndVideoViewBinding() const;
+    SImageVideoViewEntityBinding SpawnImageAndVideoView() const;
 
   private:
-    ZEntityRef m_rImageVideoView;
+    std::unique_ptr<ZTemplateEntitySpawner> m_pViewSpawner;
+
+    ZEntityRef m_rLastSpawnedViewEntity; // for debug UI
 };

--- a/src/Effects/Base/Companion/ZHUDImageVideoViewEffectBase.h
+++ b/src/Effects/Base/Companion/ZHUDImageVideoViewEffectBase.h
@@ -27,7 +27,7 @@ class ZHUDImageVideoViewEffectBase : public virtual ZCompanionModDependentEffect
     void OnDrawDebugUI() override;
 
   protected:
-    SImageVideoViewEntityBinding SpawnImageAndVideoView() const;
+    SImageVideoViewEntityBinding SpawnImageAndVideoView();
 
   private:
     std::unique_ptr<ZTemplateEntitySpawner> m_pViewSpawner;

--- a/src/Effects/Base/Companion/ZHUDImageVideoViewEffectBase.h
+++ b/src/Effects/Base/Companion/ZHUDImageVideoViewEffectBase.h
@@ -1,0 +1,30 @@
+#pragma once
+#include "Effects/Base/Companion/ZCompanionModDependentEffectBase.h"
+
+#include "Entity/Bindings/SImageVideoViewEntityBinding.h"
+
+/**
+ * Base class for accessing HUD Image / Video view added by companion mod.
+ * Note that you'll have to handle loading of the image / video resource yourself (via ZResourceProvider).
+ */
+class ZHUDImageVideoViewEffectBase : public virtual ZCompanionModDependentEffectBase
+{
+  public:
+    ZHUDImageVideoViewEffectBase()
+        : ZCompanionModDependentEffectBase(CompanionModUtil::SVersion(1, 4, 0)) // Image / Video view added in 1.4.0
+    {
+    }
+
+    void OnEnterScene() override;
+    void OnClearScene() override;
+    bool Available() const override;
+    bool IsCompatibleWith(const IChaosEffect* p_pOther) const override;
+
+    void OnDrawDebugUI() override;
+
+  protected:
+    SImageVideoViewEntityBinding GetImageAndVideoViewBinding() const;
+
+  private:
+    ZEntityRef m_rImageVideoView;
+};

--- a/src/Effects/Meta/ZFakeConnectionLostEffect.cpp
+++ b/src/Effects/Meta/ZFakeConnectionLostEffect.cpp
@@ -1,0 +1,30 @@
+#include "ZFakeConnectionLostEffect.h"
+
+#include "Registry.h"
+#include "Helpers/EntityUtils.h"
+#include "Entity/EntityIds.h"
+
+void ZFakeConnectionLostEffect::OnEnterScene()
+{
+    auto s_rDialog = Utils::ZEntityFinder()
+                         .EntityID(EntityId::CompanionMod::GameEssentials::UIModalDisconnectedFake)
+                         .FindFirst();
+    m_FakeDisconnectDialog = SGenericModalDialogTwoButtonsEntityBinding(s_rDialog);
+}
+
+void ZFakeConnectionLostEffect::OnClearScene()
+{
+    m_FakeDisconnectDialog = {};
+}
+
+bool ZFakeConnectionLostEffect::Available() const
+{
+    return IChaosEffect::Available() && m_FakeDisconnectDialog;
+}
+
+void ZFakeConnectionLostEffect::Start()
+{
+    m_FakeDisconnectDialog.Show();
+}
+
+REGISTER_CHAOS_EFFECT(ZFakeConnectionLostEffect)

--- a/src/Effects/Meta/ZFakeConnectionLostEffect.h
+++ b/src/Effects/Meta/ZFakeConnectionLostEffect.h
@@ -1,0 +1,26 @@
+#pragma once
+#include "IChaosEffect.h"
+
+#include "Entity/Bindings/SGenericModalDialogTwoButtonsEntityBinding.h"
+
+class ZFakeConnectionLostEffect : public IChaosEffect
+{
+    void OnEnterScene() override;
+    void OnClearScene() override;
+    bool Available() const override;
+
+    void Start() override;
+
+    EDuration GetDuration() const override
+    {
+        return EDuration::OneShot;
+    }
+
+    std::string GetDisplayName(const bool p_bVoting) const override
+    {
+        return "Unstable Internet";
+    }
+
+  private:
+    SGenericModalDialogTwoButtonsEntityBinding m_FakeDisconnectDialog;
+};

--- a/src/Effects/UI/ZBouncyMinimapEffect.cpp
+++ b/src/Effects/UI/ZBouncyMinimapEffect.cpp
@@ -1,0 +1,137 @@
+#include "ZBouncyMinimapEffect.h"
+
+#include <imgui.h>
+#include <Logging.h>
+
+#include <Glacier/SGameUpdateEvent.h>
+
+#include "Registry.h"
+#include "ZConfigurationAccessor.h"
+#include "Helpers/Math.h"
+#include "Helpers/Utils.h"
+#include "Helpers/EntityUtils.h"
+
+#include "Entity/EntityIds.h"
+#include "Entity/Bindings/SZUIControlEntityBinding.h"
+
+#include "Effects/UI/ZNoHUDEffect.h"
+#include "Effects/UI/ZLargeMinimapEffect.h"
+
+#define TAG "[ZBouncyMinimapEffect] "
+
+void ZBouncyMinimapEffect::OnEnterScene()
+{
+    m_rMinimapContainer = Utils::ZEntityFinder()
+                              .EntityID(EntityId::HM3::Minimap::Container)
+                              .FindFirst();
+    m_bActive = false;
+}
+
+void ZBouncyMinimapEffect::OnClearScene()
+{
+    m_rMinimapContainer = {};
+    m_bActive = false;
+}
+
+bool ZBouncyMinimapEffect::Available() const
+{
+    return IChaosEffect::Available()
+           && m_rMinimapContainer;
+}
+
+bool ZBouncyMinimapEffect::IsCompatibleWith(const IChaosEffect* p_pOther) const
+{
+    return IChaosEffect::IsCompatibleWith(p_pOther)
+           // joke doesn't really work when HUD is not visible...
+           && !Utils::IsInstanceOf<ZNoHUDEffect>(p_pOther)
+
+           // math doesn't work out with this one active
+           && !Utils::IsInstanceOf<ZLargeMinimapEffect>(p_pOther);
+}
+
+void ZBouncyMinimapEffect::OnDrawDebugUI()
+{
+    ImGui::TextUnformatted(fmt::format("Position: {}, {}", m_vPosition.x, m_vPosition.y).c_str());
+    ImGui::TextUnformatted(fmt::format("Velocity: {}, {}", m_vVelocity.x, m_vVelocity.y).c_str());
+
+    ImGui::DragFloat("Velocity Multiplier", &m_fVelocityMultiplier, 1.f);
+
+    ImGui::DragFloat2("Bounds Min", &m_vBoundsMin.x, .1f);
+    ImGui::DragFloat2("Bounds Max", &m_vBoundsMax.x, .1f);
+}
+
+void ZBouncyMinimapEffect::Start()
+{
+    auto s_ContainerBinding = SZUIControlEntityBinding(m_rMinimapContainer);
+    if (!s_ContainerBinding)
+    {
+        return;
+    }
+
+    const auto s_vPos = s_ContainerBinding.m_vPositionOffset;
+    if (!s_vPos.has_value())
+    {
+        return;
+    }
+
+    m_vPosition = SVector2(s_vPos.value().x, s_vPos.value().y);
+    m_vVelocity = SVector2(
+        Math::GetRandomNumber<float32>(-15.f, 15.f),
+        Math::GetRandomNumber<float32>(-15.f, 15.f)
+    );
+    m_bActive = true;
+}
+
+void ZBouncyMinimapEffect::Stop()
+{
+    m_bActive = false;
+
+    auto s_ContainerBinding = SZUIControlEntityBinding(m_rMinimapContainer);
+    s_ContainerBinding.m_vPositionOffset = SVector3(419.f, -16.f, 0.f); // default from minimap TEMP
+}
+
+void ZBouncyMinimapEffect::OnFrameUpdate(const SGameUpdateEvent& p_UpdateEvent, const float32 p_fEffectTimeRemaining)
+{
+    if (!m_bActive || !m_rMinimapContainer)
+    {
+        return;
+    }
+
+    auto s_ContainerBinding = SZUIControlEntityBinding(m_rMinimapContainer);
+    if (!s_ContainerBinding)
+    {
+        return;
+    }
+
+    // apply velocity
+    const auto s_fDeltaTime = static_cast<float32>(p_UpdateEvent.m_GameTimeDelta.ToSeconds());
+    m_vPosition.x += m_vVelocity.x * m_fVelocityMultiplier * s_fDeltaTime;
+    m_vPosition.y += m_vVelocity.y * m_fVelocityMultiplier * s_fDeltaTime;
+
+    // when hitting bounds, limit position and apply randomized (inverse) bouncy velocity
+    if (m_vPosition.x < m_vBoundsMin.x)
+    {
+        m_vPosition.x = m_vBoundsMin.x;
+        m_vVelocity.x *= Math::GetRandomNumber<float32>(-1.2f, -0.8f);
+    }
+    if (m_vPosition.x > m_vBoundsMax.x)
+    {
+        m_vPosition.x = m_vBoundsMax.x;
+        m_vVelocity.x *= Math::GetRandomNumber<float32>(-1.2f, -0.8f);
+    }
+    if (m_vPosition.y < m_vBoundsMin.y)
+    {
+        m_vPosition.y = m_vBoundsMin.y;
+        m_vVelocity.y *= Math::GetRandomNumber<float32>(-1.2f, -0.8f);
+    }
+    if (m_vPosition.y > m_vBoundsMax.y)
+    {
+        m_vPosition.y = m_vBoundsMax.y;
+        m_vVelocity.y *= Math::GetRandomNumber<float32>(-1.2f, -0.8f);
+    }
+
+    // set position ignoring z
+    s_ContainerBinding.m_vPositionOffset = SVector3(m_vPosition.x, m_vPosition.y, 0.f);
+}
+
+REGISTER_CHAOS_EFFECT(ZBouncyMinimapEffect);

--- a/src/Effects/UI/ZBouncyMinimapEffect.h
+++ b/src/Effects/UI/ZBouncyMinimapEffect.h
@@ -1,0 +1,37 @@
+#pragma once
+#include "IChaosEffect.h"
+
+#include <Glacier/ZEntity.h>
+#include <Glacier/ZMath.h>
+
+class ZBouncyMinimapEffect : public IChaosEffect
+{
+  public:
+    void OnEnterScene() override;
+    void OnClearScene() override;
+    bool Available() const override;
+    bool IsCompatibleWith(const IChaosEffect* p_pOther) const override;
+
+    void OnDrawDebugUI() override;
+
+    void Start() override;
+    void Stop() override;
+    void OnFrameUpdate(const SGameUpdateEvent& p_UpdateEvent, const float32 p_fEffectTimeRemaining) override;
+
+    std::string GetDisplayName(const bool p_bVoting) const override
+    {
+        return "Bouncy Minimap";
+    }
+
+  private:
+    SVector2 m_vBoundsMin = SVector2(300.f, -2315.f);
+    SVector2 m_vBoundsMax = SVector2(5035.f, 90.f);
+    float32 m_fVelocityMultiplier = 200.f;
+
+  private:
+    bool m_bActive = false;
+    ZEntityRef m_rMinimapContainer;
+
+    SVector2 m_vPosition = SVector2(0.f, 0.f);
+    SVector2 m_vVelocity = SVector2(0.f, 0.f);
+};

--- a/src/Effects/UI/ZCustomReticleEffect.cpp
+++ b/src/Effects/UI/ZCustomReticleEffect.cpp
@@ -14,31 +14,16 @@ void ZCustomReticleEffect::LoadResources()
 {
     ZHUDImageVideoViewEffectBase::LoadResources();
 
-#define ADD_IMAGE(PATH, ALLOW_H_FLIP, ALLOW_V_FLIP)                                                      \
-    if (auto s_pResource = ZResourceProvider::Create<PATH>(); s_pResource && s_pResource->IsAvailable()) \
-    {                                                                                                    \
-        Logger::Debug(TAG "Loaded resource: " PATH);                                                     \
-        SReticleImageItem s_Item = {std::move(s_pResource), ALLOW_H_FLIP, ALLOW_V_FLIP};                 \
-        m_aReticleImages.emplace_back(s_Item);                                                           \
-    }                                                                                                    \
-    else                                                                                                 \
-    {                                                                                                    \
-        Logger::Warn(TAG "Failed to load resource: " PATH);                                              \
-    }
-
-    // NOTE: images must be in chunk0 for this to work
-    // NOTE: this assumes images are 1920x1080.
-    // NOTE: second and third parameter specifies whether the image may be flipped horizontally / vertically.
-    if (HasCompanionMod(CompanionModUtil::SVersion(1, 4, 0)))
+    m_pImageResource = ZResourceProvider::Create(m_sImageResourcePath);
+    if (m_pImageResource && m_pImageResource->IsAvailable())
     {
-        ADD_IMAGE("[assembly:/_pro/chaosmod/custom_reticle/gura.png].pc_gfx", true, false);
-        ADD_IMAGE("[assembly:/_pro/chaosmod/custom_reticle/spiderman.png].pc_gfx", false, false);
-        ADD_IMAGE("[assembly:/_pro/chaosmod/custom_reticle/leo.png].pc_gfx", true, false);
-        ADD_IMAGE("[assembly:/_pro/chaosmod/custom_reticle/amogus.png].pc_gfx", true, false);
-        ADD_IMAGE("[assembly:/_pro/chaosmod/custom_reticle/clickbait.png].pc_gfx", false, false);
+        Logger::Debug(TAG "Loaded resource: {}", m_sImageResourcePath);
     }
-
-#undef ADD_IMAGE
+    else
+    {
+        Logger::Warn(TAG "Failed to load resource: {}", m_sImageResourcePath);
+        m_pImageResource = nullptr;
+    }
 }
 
 void ZCustomReticleEffect::OnEnterScene()
@@ -54,50 +39,27 @@ void ZCustomReticleEffect::OnEnterScene()
 void ZCustomReticleEffect::OnClearScene()
 {
     ZHUDImageVideoViewEffectBase::OnClearScene();
-    m_aReticleImages.clear();
+    m_pImageResource = nullptr;
     m_ReticleView = {};
+    m_OriginalReticle = {};
     m_bTrackReticle = false;
 }
 
 bool ZCustomReticleEffect::Available() const
 {
     return ZHUDImageVideoViewEffectBase::Available()
-           && !m_aReticleImages.empty()
-           && m_ReticleView;
+           && m_pImageResource && m_pImageResource->IsAvailable()
+           && m_ReticleView
+           && m_OriginalReticle;
 }
 
 void ZCustomReticleEffect::OnDrawDebugUI()
 {
-    int i = 0;
-    for (const auto& s_Item : m_aReticleImages)
-    {
-        const auto& s_pResource = s_Item.m_pResource;
-
-        if (ImGui::Button(("SET##" + std::to_string(i)).c_str()))
-        {
-            m_ReticleView.m_ridImage = s_pResource->GetResourceID();
-        }
-
-        ImGui::SameLine();
-        std::string s_sFlipInfo = "";
-        if (s_Item.m_bAllowFlipHorizontal)
-        {
-            s_sFlipInfo += "H";
-        }
-        if (s_Item.m_bAllowFlipVertical)
-        {
-            s_sFlipInfo += "V";
-        }
-        ImGui::TextUnformatted(s_sFlipInfo.c_str());
-
-        ImGui::SameLine();
-        ImGui::TextUnformatted(fmt::format("{}", s_pResource->ToString()).c_str());
-
-        i++;
-    }
+    ImGui::Checkbox("Allow Flip Horizontal", &m_bAllowFlipHorizontal);
+    ImGui::Checkbox("Allow Flip Vertical", &m_bAllowFlipVertical);
 
     ImGui::BeginDisabled();
-    ImGui::Checkbox("Track Reticle", &m_bTrackReticle);
+    ImGui::Checkbox("Is Tracking Reticle", &m_bTrackReticle);
     ImGui::EndDisabled();
 
     if (ImGui::Button("Flip Horizontal"))
@@ -122,22 +84,20 @@ void ZCustomReticleEffect::OnDrawDebugUI()
 
 void ZCustomReticleEffect::Start()
 {
-    const auto s_Reticle = Math::SelectRandomElement(m_aReticleImages);
-    const auto& s_pImageResource = s_Reticle.m_pResource;
-    if (!s_pImageResource || !s_pImageResource->IsAvailable())
+    if (!m_pImageResource || !m_pImageResource->IsAvailable())
     {
         Logger::Error(TAG "Failed to set reticle image!");
         return;
     }
 
-    m_ReticleView.m_ridImage = s_pImageResource->GetResourceID();
+    m_ReticleView.m_ridImage = m_pImageResource->GetResourceID();
 
     auto s_vSize = SVector2(1.f, 1.f);
-    if (s_Reticle.m_bAllowFlipHorizontal && Math::GetRandomBool(.5f))
+    if (m_bAllowFlipHorizontal && Math::GetRandomBool(.5f))
     {
         s_vSize.x *= -1.f;
     }
-    if (s_Reticle.m_bAllowFlipVertical && Math::GetRandomBool(.5f))
+    if (m_bAllowFlipVertical && Math::GetRandomBool(.5f))
     {
         s_vSize.y *= -1.f;
     }
@@ -167,4 +127,42 @@ void ZCustomReticleEffect::OnFrameUpdate(const SGameUpdateEvent& p_UpdateEvent, 
     }
 }
 
-REGISTER_CHAOS_EFFECT(ZCustomReticleEffect);
+REGISTER_CHAOS_EFFECT_PARAM(
+    gura,
+    ZCustomReticleEffect,
+    "gura",                                                     // name
+    "Gura",                                                     // display name
+    "[assembly:/_pro/chaosmod/custom_reticle/gura.png].pc_gfx", // res path
+    true,                                                       // allow H-flip
+    false                                                       // allow V-flip
+);
+REGISTER_CHAOS_EFFECT_PARAM(
+    spiderman,
+    ZCustomReticleEffect,
+    "spiderman",                                                    // name
+    "Spiderman",                                                    // display name
+    "[assembly:/_pro/chaosmod/custom_reticle/spiderman.png].pc_gfx" // res path
+);
+REGISTER_CHAOS_EFFECT_PARAM(
+    leo,
+    ZCustomReticleEffect,
+    "leo",                                                     // name
+    "Leo",                                                     // display name
+    "[assembly:/_pro/chaosmod/custom_reticle/leo.png].pc_gfx", // res path
+    true                                                       // allow H-flip
+);
+REGISTER_CHAOS_EFFECT_PARAM(
+    amogus,
+    ZCustomReticleEffect,
+    "amogus",                                                     // name
+    "Amogus",                                                     // display name
+    "[assembly:/_pro/chaosmod/custom_reticle/amogus.png].pc_gfx", // res path
+    true                                                          // allow H-flip
+);
+REGISTER_CHAOS_EFFECT_PARAM(
+    clickbait,
+    ZCustomReticleEffect,
+    "clickbait",                                                    // name
+    "Clickbait",                                                    // display name
+    "[assembly:/_pro/chaosmod/custom_reticle/clickbait.png].pc_gfx" // res path
+);

--- a/src/Effects/UI/ZCustomReticleEffect.cpp
+++ b/src/Effects/UI/ZCustomReticleEffect.cpp
@@ -32,6 +32,10 @@ void ZCustomReticleEffect::LoadResources()
     if (HasCompanionMod(CompanionModUtil::SVersion(1, 4, 0)))
     {
         ADD_IMAGE("[assembly:/_pro/chaosmod/custom_reticle/gura.png].pc_gfx", true, false);
+        ADD_IMAGE("[assembly:/_pro/chaosmod/custom_reticle/spiderman.png].pc_gfx", false, false);
+        ADD_IMAGE("[assembly:/_pro/chaosmod/custom_reticle/leo.png].pc_gfx", true, false);
+        ADD_IMAGE("[assembly:/_pro/chaosmod/custom_reticle/amogus.png].pc_gfx", true, false);
+        ADD_IMAGE("[assembly:/_pro/chaosmod/custom_reticle/clickbait.png].pc_gfx", false, false);
     }
 
 #undef ADD_IMAGE

--- a/src/Effects/UI/ZCustomReticleEffect.cpp
+++ b/src/Effects/UI/ZCustomReticleEffect.cpp
@@ -1,0 +1,166 @@
+#include "ZCustomReticleEffect.h"
+
+#include <imgui.h>
+#include <Logging.h>
+
+#include "Registry.h"
+#include "Helpers/Math.h"
+
+#include "Entity/EntityIds.h"
+
+#define TAG "[ZCustomReticleEffect] "
+
+void ZCustomReticleEffect::LoadResources()
+{
+    ZHUDImageVideoViewEffectBase::LoadResources();
+
+#define ADD_IMAGE(PATH, ALLOW_H_FLIP, ALLOW_V_FLIP)                                                      \
+    if (auto s_pResource = ZResourceProvider::Create<PATH>(); s_pResource && s_pResource->IsAvailable()) \
+    {                                                                                                    \
+        Logger::Debug(TAG "Loaded resource: " PATH);                                                     \
+        SReticleImageItem s_Item = {std::move(s_pResource), ALLOW_H_FLIP, ALLOW_V_FLIP};                 \
+        m_aReticleImages.emplace_back(s_Item);                                                           \
+    }                                                                                                    \
+    else                                                                                                 \
+    {                                                                                                    \
+        Logger::Warn(TAG "Failed to load resource: " PATH);                                              \
+    }
+
+    // NOTE: images must be in chunk0 for this to work
+    // NOTE: this assumes images are 1920x1080.
+    // NOTE: second and third parameter specifies whether the image may be flipped horizontally / vertically.
+    if (HasCompanionMod(CompanionModUtil::SVersion(1, 4, 0)))
+    {
+        ADD_IMAGE("[assembly:/_pro/chaosmod/custom_reticle/gura.png].pc_gfx", true, false);
+    }
+
+#undef ADD_IMAGE
+}
+
+void ZCustomReticleEffect::OnEnterScene()
+{
+    m_ReticleView = SpawnImageAndVideoView();
+    m_OriginalReticle = Utils::ZEntityFinder()
+                            .EntityID(EntityId::HM3::GameEssentials::HUDReticle)
+                            .FindFirst();
+
+    m_bTrackReticle = false;
+}
+
+void ZCustomReticleEffect::OnClearScene()
+{
+    ZHUDImageVideoViewEffectBase::OnClearScene();
+    m_aReticleImages.clear();
+    m_ReticleView = {};
+    m_bTrackReticle = false;
+}
+
+bool ZCustomReticleEffect::Available() const
+{
+    return ZHUDImageVideoViewEffectBase::Available()
+           && !m_aReticleImages.empty()
+           && m_ReticleView;
+}
+
+void ZCustomReticleEffect::OnDrawDebugUI()
+{
+    int i = 0;
+    for (const auto& s_Item : m_aReticleImages)
+    {
+        const auto& s_pResource = s_Item.m_pResource;
+
+        if (ImGui::Button(("SET##" + std::to_string(i)).c_str()))
+        {
+            m_ReticleView.m_ridImage = s_pResource->GetResourceID();
+        }
+
+        ImGui::SameLine();
+        std::string s_sFlipInfo = "";
+        if (s_Item.m_bAllowFlipHorizontal)
+        {
+            s_sFlipInfo += "H";
+        }
+        if (s_Item.m_bAllowFlipVertical)
+        {
+            s_sFlipInfo += "V";
+        }
+        ImGui::TextUnformatted(s_sFlipInfo.c_str());
+
+        ImGui::SameLine();
+        ImGui::TextUnformatted(fmt::format("{}", s_pResource->ToString()).c_str());
+
+        i++;
+    }
+
+    ImGui::BeginDisabled();
+    ImGui::Checkbox("Track Reticle", &m_bTrackReticle);
+    ImGui::EndDisabled();
+
+    if (ImGui::Button("Flip Horizontal"))
+    {
+        if (auto s_vSize = m_ReticleView.m_vSize; s_vSize.has_value())
+        {
+            m_ReticleView.m_vSize = SVector2(-s_vSize->x, s_vSize->y);
+        }
+    }
+
+    if (ImGui::Button("Flip Vertical"))
+    {
+        if (auto s_vSize = m_ReticleView.m_vSize; s_vSize.has_value())
+        {
+            m_ReticleView.m_vSize = SVector2(s_vSize->x, -s_vSize->y);
+        }
+    }
+
+    ImGui::SeparatorText("ZHUDImageVideoViewEffectBase");
+    ZHUDImageVideoViewEffectBase::OnDrawDebugUI();
+}
+
+void ZCustomReticleEffect::Start()
+{
+    const auto s_Reticle = Math::SelectRandomElement(m_aReticleImages);
+    const auto& s_pImageResource = s_Reticle.m_pResource;
+    if (!s_pImageResource || !s_pImageResource->IsAvailable())
+    {
+        Logger::Error(TAG "Failed to set reticle image!");
+        return;
+    }
+
+    m_ReticleView.m_ridImage = s_pImageResource->GetResourceID();
+
+    auto s_vSize = SVector2(1.f, 1.f);
+    if (s_Reticle.m_bAllowFlipHorizontal && Math::GetRandomBool(.5f))
+    {
+        s_vSize.x *= -1.f;
+    }
+    if (s_Reticle.m_bAllowFlipVertical && Math::GetRandomBool(.5f))
+    {
+        s_vSize.y *= -1.f;
+    }
+    m_ReticleView.m_vSize = s_vSize;
+
+    m_ReticleView.m_vPositionOffset = SVector3(0.f, 0.f, 0.f);
+    m_ReticleView.m_vRotation = SVector3(0.f, 0.f, 0.f);
+
+    m_ReticleView.m_bVideoIsVisible = false;
+
+    // sets image visible for us
+    m_bTrackReticle = true;
+}
+
+void ZCustomReticleEffect::Stop()
+{
+    m_bTrackReticle = false;
+    m_ReticleView.m_bImageIsVisible = false;
+}
+
+void ZCustomReticleEffect::OnFrameUpdate(const SGameUpdateEvent& p_UpdateEvent, const float32 p_fEffectTimeRemaining)
+{
+    if (m_bTrackReticle && m_ReticleView && m_OriginalReticle)
+    {
+        m_ReticleView.m_bImageIsVisible = m_OriginalReticle.m_bIsVisible.value_or(false);
+        m_ReticleView.m_vPositionOffset = m_OriginalReticle.m_vPositionOffset.value_or(SVector3(0.f, 0.f, 0.f));
+    }
+}
+
+REGISTER_CHAOS_EFFECT(ZCustomReticleEffect);

--- a/src/Effects/UI/ZCustomReticleEffect.h
+++ b/src/Effects/UI/ZCustomReticleEffect.h
@@ -1,0 +1,41 @@
+#include "Effects/Base/Companion/ZHUDImageVideoViewEffectBase.h"
+
+#include "Helpers/ZResourceProvider.h"
+
+#include "Entity/Bindings/SZUIControlEntityBinding.h"
+
+#include <vector>
+
+// IOI calls their crosshair a "reticle" bc they're fancy.
+class ZCustomReticleEffect : public ZHUDImageVideoViewEffectBase
+{
+  public:
+    void LoadResources() override;
+    void OnEnterScene() override;
+    void OnClearScene() override;
+    bool Available() const override;
+
+    void OnDrawDebugUI() override;
+
+    void Start();
+    void Stop();
+    void OnFrameUpdate(const SGameUpdateEvent& p_UpdateEvent, const float32 p_fEffectTimeRemaining) override;
+
+    std::string GetDisplayName(const bool p_bVoting) const override
+    {
+        return "Aim Assist";
+    }
+
+  private:
+    struct SReticleImageItem
+    {
+        std::shared_ptr<ZResourceProvider> m_pResource;
+        bool m_bAllowFlipHorizontal;
+        bool m_bAllowFlipVertical;
+    };
+
+    std::vector<SReticleImageItem> m_aReticleImages;
+    SImageVideoViewEntityBinding m_ReticleView;
+    SZUIControlEntityBinding m_OriginalReticle;
+    bool m_bTrackReticle = false;
+};

--- a/src/Effects/UI/ZCustomReticleEffect.h
+++ b/src/Effects/UI/ZCustomReticleEffect.h
@@ -10,6 +10,22 @@
 class ZCustomReticleEffect : public ZHUDImageVideoViewEffectBase
 {
   public:
+    ZCustomReticleEffect(
+        const std::string& p_sNameSuffix,
+        const std::string& p_sDisplayNameSuffix,
+        const std::string& p_sImageResourcePath,
+        const bool p_bAllowFlipHorizontal = false,
+        const bool p_bAllowFlipVertical = false
+    )
+        : ZHUDImageVideoViewEffectBase(),
+          m_sNameSuffix(p_sNameSuffix),
+          m_sDisplayNameSuffix(p_sDisplayNameSuffix),
+          m_sImageResourcePath(p_sImageResourcePath),
+          m_bAllowFlipHorizontal(p_bAllowFlipHorizontal),
+          m_bAllowFlipVertical(p_bAllowFlipVertical)
+    {
+    }
+
     void LoadResources() override;
     void OnEnterScene() override;
     void OnClearScene() override;
@@ -21,20 +37,31 @@ class ZCustomReticleEffect : public ZHUDImageVideoViewEffectBase
     void Stop();
     void OnFrameUpdate(const SGameUpdateEvent& p_UpdateEvent, const float32 p_fEffectTimeRemaining) override;
 
+    std::string GetName() const override
+    {
+        return ZHUDImageVideoViewEffectBase::GetName() + "_" + m_sNameSuffix;
+    }
+
     std::string GetDisplayName(const bool p_bVoting) const override
     {
-        return "Aim Assist";
+        std::string s_sName = "Aim Assist";
+        if (!p_bVoting)
+        {
+            s_sName += " (" + m_sDisplayNameSuffix + ")";
+        }
+
+        return s_sName;
     }
 
   private:
-    struct SReticleImageItem
-    {
-        std::shared_ptr<ZResourceProvider> m_pResource;
-        bool m_bAllowFlipHorizontal;
-        bool m_bAllowFlipVertical;
-    };
+    std::string m_sNameSuffix;
+    std::string m_sDisplayNameSuffix;
+    std::string m_sImageResourcePath;
+    bool m_bAllowFlipHorizontal;
+    bool m_bAllowFlipVertical;
 
-    std::vector<SReticleImageItem> m_aReticleImages;
+  private:
+    std::unique_ptr<ZResourceProvider> m_pImageResource;
     SImageVideoViewEntityBinding m_ReticleView;
     SZUIControlEntityBinding m_OriginalReticle;
     bool m_bTrackReticle = false;

--- a/src/Effects/UI/ZCustomReticleEffect.h
+++ b/src/Effects/UI/ZCustomReticleEffect.h
@@ -1,3 +1,4 @@
+#pragma once
 #include "Effects/Base/Companion/ZHUDImageVideoViewEffectBase.h"
 
 #include "Helpers/ZResourceProvider.h"

--- a/src/Effects/UI/ZLargeMinimapEffect.cpp
+++ b/src/Effects/UI/ZLargeMinimapEffect.cpp
@@ -91,7 +91,7 @@ void ZLargeMinimapEffect::SetMaximap(const bool p_bEnabled)
         // set maximap configuration
         // to find these, you'll have to test manually.
         // it seems to me that IOI's doing some weird offset in a offset kinda thing, but idk
-        // i didn't look to much into it
+        // i didn't look too much into it
         s_ContainerBinding.m_vSize = SVector2(75.f, 75.f);
         s_ContainerBinding.m_eAlignmentType = ZUIControlLayoutLegacyAspect_EAlignmentType::E_ALIGNMENT_TYPE_Center;
         s_ContainerBinding.m_vPositionOffset = SVector3(405.f, 405.f, 0.f);

--- a/src/Effects/UI/ZLargeMinimapEffect.cpp
+++ b/src/Effects/UI/ZLargeMinimapEffect.cpp
@@ -1,0 +1,123 @@
+#include "ZLargeMinimapEffect.h"
+
+#include <imgui.h>
+#include <Logging.h>
+
+#include "Registry.h"
+#include "ZConfigurationAccessor.h"
+#include "Helpers/Utils.h"
+#include "Helpers/EntityUtils.h"
+
+#include "Entity/EntityIds.h"
+#include "Entity/Bindings/SZUIControlEntityBinding.h"
+
+#include "Effects/UI/ZNoHUDEffect.h"
+
+#define TAG "[ZLargeMinimapEffect] "
+
+void ZLargeMinimapEffect::OnEnterScene()
+{
+    m_rMinimapContainer = Utils::ZEntityFinder()
+                              .EntityID(EntityId::HM3::Minimap::Container)
+                              .FindFirst();
+    m_rMinimapHUDStatusMarkers = Utils::ZEntityFinder()
+                                     .EntityID(EntityId::HM3::Minimap::HUDStatusMarkers)
+                                     .FindFirst();
+}
+
+void ZLargeMinimapEffect::OnClearScene()
+{
+    m_rMinimapContainer = {};
+    m_rMinimapHUDStatusMarkers = {};
+}
+
+bool ZLargeMinimapEffect::Available() const
+{
+    return IChaosEffect::Available()
+           && m_rMinimapContainer
+           && m_rMinimapHUDStatusMarkers;
+}
+
+bool ZLargeMinimapEffect::IsCompatibleWith(const IChaosEffect* p_pOther) const
+{
+    return IChaosEffect::IsCompatibleWith(p_pOther)
+           // joke doesn't really work when HUD is not visible...
+           && !Utils::IsInstanceOf<ZNoHUDEffect>(p_pOther);
+}
+
+void ZLargeMinimapEffect::LoadConfiguration(const ZConfigurationAccessor* p_pConfiguration)
+{
+    IChaosEffect::LoadConfiguration(p_pConfiguration);
+
+    m_bReduceAlpha = p_pConfiguration->GetBool("ReduceAlpha", false);
+}
+
+void ZLargeMinimapEffect::DrawConfigUI(ZConfigurationAccessor* p_pConfiguration)
+{
+    IChaosEffect::DrawConfigUI(p_pConfiguration);
+
+    if (ImGui::Checkbox("Reduce Minimap Opacity", &m_bReduceAlpha))
+    {
+        p_pConfiguration->SetBool("ReduceAlpha", m_bReduceAlpha);
+    }
+    if (ImGui::IsItemHovered())
+    {
+        ImGui::SetTooltip("Reduce the opacity of the minimap when active, so you don't have to go \"i can't see half my screen\", as if that wasn't the point of this.");
+    }
+}
+
+void ZLargeMinimapEffect::Start()
+{
+    SetMaximap(true);
+}
+
+void ZLargeMinimapEffect::Stop()
+{
+    SetMaximap(false);
+}
+
+void ZLargeMinimapEffect::SetMaximap(const bool p_bEnabled)
+{
+    auto s_ContainerBinding = SZUIControlEntityBinding(m_rMinimapContainer);
+    auto s_HUDStatusMarkersBinding = SZUIControlEntityBinding(m_rMinimapHUDStatusMarkers);
+    if (!s_ContainerBinding || !s_HUDStatusMarkersBinding)
+    {
+        Logger::Debug(TAG "Failed to setup bindings");
+        return;
+    }
+
+    if (p_bEnabled)
+    {
+        // set maximap configuration
+        // to find these, you'll have to test manually.
+        // it seems to me that IOI's doing some weird offset in a offset kinda thing, but idk
+        // i didn't look to much into it
+        s_ContainerBinding.m_vSize = SVector2(75.f, 75.f);
+        s_ContainerBinding.m_eAlignmentType = ZUIControlLayoutLegacyAspect_EAlignmentType::E_ALIGNMENT_TYPE_Center;
+        s_ContainerBinding.m_vPositionOffset = SVector3(405.f, 405.f, 0.f);
+
+        s_HUDStatusMarkersBinding.m_vSize = SVector2(5.8f, 5.8f);
+
+        if (m_bReduceAlpha)
+        {
+            s_ContainerBinding.m_fAlpha = 50.f;
+        }
+
+        Logger::Debug(TAG "Minimap configuration set to MAXIMAP, can you see better now?");
+    }
+    else
+    {
+        // restore default configuration, as set in minimap TEMP
+        s_ContainerBinding.m_vSize = SVector2(36.f, 36.f);
+        s_ContainerBinding.m_eAlignmentType = ZUIControlLayoutLegacyAspect_EAlignmentType::E_ALIGNMENT_TYPE_BottomLeft;
+        s_ContainerBinding.m_vPositionOffset = SVector3(419.f, -16.f, 0.f);
+
+        s_HUDStatusMarkersBinding.m_vSize = SVector2(2.778f, 2.778f); // rounded
+
+        s_ContainerBinding.m_fAlpha = 100.f;
+
+        Logger::Debug(TAG "Minimap configuration restored to default");
+    }
+}
+
+REGISTER_CHAOS_EFFECT(ZLargeMinimapEffect);

--- a/src/Effects/UI/ZLargeMinimapEffect.h
+++ b/src/Effects/UI/ZLargeMinimapEffect.h
@@ -1,0 +1,33 @@
+#pragma once
+#include "IChaosEffect.h"
+
+#include <Glacier/ZEntity.h>
+
+class ZLargeMinimapEffect : public IChaosEffect
+{
+  public:
+    void OnEnterScene() override;
+    void OnClearScene() override;
+    bool Available() const override;
+    bool IsCompatibleWith(const IChaosEffect* p_pOther) const override;
+
+    void LoadConfiguration(const ZConfigurationAccessor* p_pConfiguration) override;
+    void DrawConfigUI(ZConfigurationAccessor* p_pConfiguration) override;
+
+    void Start() override;
+    void Stop() override;
+
+    std::string GetDisplayName(const bool p_bVoting) const override
+    {
+        return "Maximap";
+    }    
+
+  private: // config
+    bool m_bReduceAlpha = false;
+
+  private:
+    ZEntityRef m_rMinimapContainer;
+    ZEntityRef m_rMinimapHUDStatusMarkers;
+
+    void SetMaximap(const bool p_bEnabled);
+};

--- a/src/Effects/UI/ZLargeMinimapEffect.h
+++ b/src/Effects/UI/ZLargeMinimapEffect.h
@@ -20,7 +20,7 @@ class ZLargeMinimapEffect : public IChaosEffect
     std::string GetDisplayName(const bool p_bVoting) const override
     {
         return "Maximap";
-    }    
+    }
 
   private: // config
     bool m_bReduceAlpha = false;

--- a/src/Effects/UI/ZLiveTvEffect.cpp
+++ b/src/Effects/UI/ZLiveTvEffect.cpp
@@ -1,0 +1,125 @@
+#include "ZLiveTvEffect.h"
+
+#include <imgui.h>
+#include <Logging.h>
+
+#include "Registry.h"
+#include "Helpers/Math.h"
+
+#define TAG "[ZLiveTvEffect] "
+
+void ZLiveTvEffect::LoadResources()
+{
+#define ADD_VIDEO(PATH)                                                                                  \
+    if (auto s_pResource = ZResourceProvider::Create<PATH>(); s_pResource && s_pResource->IsAvailable()) \
+    {                                                                                                    \
+        Logger::Debug(TAG "Loaded video resource: " PATH);                                               \
+        m_aVideoResources.emplace_back(std::move(s_pResource));                                          \
+    }                                                                                                    \
+    else                                                                                                 \
+    {                                                                                                    \
+        Logger::Warn(TAG "Failed to load video resource: " PATH);                                        \
+    }
+
+    // NOTE: videos must be ported to chunk0 for this to work
+    ADD_VIDEO("[assembly:/_pro/effects/videos/arewestars_1minloop_640x360.avi].pc_gfxv");   // Jordan Cross music video
+    ADD_VIDEO("[assembly:/_pro/effects/videos/fox_distraction_yumvideo.avi].pc_gfxv");      // Spinning Burger + Banana
+    ADD_VIDEO("[assembly:/_pro/effects/videos/kandlgameplay_640x480.avi].pc_gfxv");         // Kane & Lynch Gameplay
+    ADD_VIDEO("[assembly:/_pro/effects/videos/freedom_commercial_640x360.avi].pc_gfxv");    // "Dave's Guns" Commercial
+    ADD_VIDEO("[assembly:/_pro/effects/videos/vermont_gnn_news_all.avi].pc_gfxv");          // News Broadcast
+    ADD_VIDEO("[assembly:/_pro/effects/videos/miami_gnn_news_all.avi].pc_gfxv");            // News Broadcast
+    ADD_VIDEO("[assembly:/_pro/effects/videos/baseball_pregame_loop_640x360.avi].pc_gfxv"); // Baseball pregame show
+    ADD_VIDEO("[assembly:/_pro/effects/videos/dancemat_video_640x360_a.avi].pc_gfxv");      // Hokkaido Dance Mat - Perfect Performance
+    // ADD_VIDEO("[assembly:/_pro/effects/videos/dancemat_video_640x360_b.avi].pc_gfxv");      // Hokkaido Dance Mat - Mid Performance
+
+#undef ADD_VIDEO
+}
+
+void ZLiveTvEffect::OnEnterScene()
+{
+    ZHUDImageVideoViewEffectBase::OnEnterScene();
+}
+
+void ZLiveTvEffect::OnClearScene()
+{
+    ZHUDImageVideoViewEffectBase::OnClearScene();
+    m_aVideoResources.clear();
+}
+
+bool ZLiveTvEffect::Available() const
+{
+    return ZHUDImageVideoViewEffectBase::Available()
+           && !m_aVideoResources.empty();
+}
+
+bool ZLiveTvEffect::IsCompatibleWith(const IChaosEffect* p_pOther) const
+{
+    return ZHUDImageVideoViewEffectBase::IsCompatibleWith(p_pOther);
+}
+
+void ZLiveTvEffect::OnDrawDebugUI()
+{
+    int i = 0;
+    for (const auto& s_pResource : m_aVideoResources)
+    {
+        if (ImGui::Button(("PLAY##" + std::to_string(i)).c_str()))
+        {
+            PlayVideo(s_pResource->GetResourceID());
+        }
+
+        ImGui::SameLine();
+        ImGui::TextUnformatted(fmt::format("{}", s_pResource->ToString()).c_str());
+
+        i++;
+    }
+
+    ImGui::SeparatorText("ZHUDImageVideoViewEffectBase");
+    ZHUDImageVideoViewEffectBase::OnDrawDebugUI();
+}
+
+void ZLiveTvEffect::Start()
+{
+
+    auto s_pVideoResource = Math::SelectRandomElement(m_aVideoResources);
+    if (s_pVideoResource && s_pVideoResource->IsAvailable())
+    {
+        Logger::Debug(TAG "Playing video {}", s_pVideoResource->ToString());
+        PlayVideo(s_pVideoResource->GetResourceID());
+    }
+}
+
+void ZLiveTvEffect::Stop()
+{
+    if (auto s_View = GetImageAndVideoViewBinding())
+    {
+        s_View.m_bVideoIsVisible = false;
+        s_View.StopVideo();
+    }
+}
+
+void ZLiveTvEffect::PlayVideo(const ZRuntimeResourceID& p_ridVideo)
+{
+    auto s_View = GetImageAndVideoViewBinding();
+    if (!s_View)
+    {
+        return;
+    }
+
+    s_View.m_vPositionOffset = SVector3(
+        Math::GetRandomNumber<float32>(m_vPositionMin.x, m_vPositionMax.x),
+        Math::GetRandomNumber<float32>(m_vPositionMin.y, m_vPositionMax.y),
+        0.f
+    );
+    s_View.m_vSize = m_vSize;
+    s_View.m_vRotation = SVector3(0.f, 0.f, 0.f);
+
+    s_View.m_ridVideo = p_ridVideo;
+    s_View.m_bVideoLoop = true;
+
+    s_View.m_bImageIsVisible = false;
+    s_View.m_bVideoIsVisible = true;
+
+    s_View.PlayVideo();
+}
+
+REGISTER_CHAOS_EFFECT(ZLiveTvEffect);

--- a/src/Effects/UI/ZLiveTvEffect.cpp
+++ b/src/Effects/UI/ZLiveTvEffect.cpp
@@ -12,6 +12,8 @@ void ZLiveTvEffect::LoadResources()
 {
     ZHUDImageVideoViewEffectBase::LoadResources();
 
+    m_aVideoResources.clear();
+
 #define ADD_VIDEO(PATH)                                                                                  \
     if (auto s_pResource = ZResourceProvider::Create<PATH>(); s_pResource && s_pResource->IsAvailable()) \
     {                                                                                                    \

--- a/src/Effects/UI/ZLiveTvEffect.cpp
+++ b/src/Effects/UI/ZLiveTvEffect.cpp
@@ -10,6 +10,8 @@
 
 void ZLiveTvEffect::LoadResources()
 {
+    ZHUDImageVideoViewEffectBase::LoadResources();
+
 #define ADD_VIDEO(PATH)                                                                                  \
     if (auto s_pResource = ZResourceProvider::Create<PATH>(); s_pResource && s_pResource->IsAvailable()) \
     {                                                                                                    \
@@ -35,26 +37,17 @@ void ZLiveTvEffect::LoadResources()
 #undef ADD_VIDEO
 }
 
-void ZLiveTvEffect::OnEnterScene()
-{
-    ZHUDImageVideoViewEffectBase::OnEnterScene();
-}
-
 void ZLiveTvEffect::OnClearScene()
 {
     ZHUDImageVideoViewEffectBase::OnClearScene();
     m_aVideoResources.clear();
+    m_aActiveVideoViews.clear();
 }
 
 bool ZLiveTvEffect::Available() const
 {
     return ZHUDImageVideoViewEffectBase::Available()
            && !m_aVideoResources.empty();
-}
-
-bool ZLiveTvEffect::IsCompatibleWith(const IChaosEffect* p_pOther) const
-{
-    return ZHUDImageVideoViewEffectBase::IsCompatibleWith(p_pOther);
 }
 
 void ZLiveTvEffect::OnDrawDebugUI()
@@ -73,6 +66,8 @@ void ZLiveTvEffect::OnDrawDebugUI()
         i++;
     }
 
+    ImGui::TextUnformatted(fmt::format("Currently Active: {}", m_aActiveVideoViews.size()).c_str());
+
     ImGui::SeparatorText("ZHUDImageVideoViewEffectBase");
     ZHUDImageVideoViewEffectBase::OnDrawDebugUI();
 }
@@ -90,16 +85,18 @@ void ZLiveTvEffect::Start()
 
 void ZLiveTvEffect::Stop()
 {
-    if (auto s_View = GetImageAndVideoViewBinding())
+    for (auto s_View : m_aActiveVideoViews)
     {
         s_View.m_bVideoIsVisible = false;
         s_View.StopVideo();
     }
+
+    m_aActiveVideoViews.clear();
 }
 
 void ZLiveTvEffect::PlayVideo(const ZRuntimeResourceID& p_ridVideo)
 {
-    auto s_View = GetImageAndVideoViewBinding();
+    auto s_View = SpawnImageAndVideoView();
     if (!s_View)
     {
         return;
@@ -120,6 +117,8 @@ void ZLiveTvEffect::PlayVideo(const ZRuntimeResourceID& p_ridVideo)
     s_View.m_bVideoIsVisible = true;
 
     s_View.PlayVideo();
+
+    m_aActiveVideoViews.emplace_back(s_View);
 }
 
 REGISTER_CHAOS_EFFECT(ZLiveTvEffect);

--- a/src/Effects/UI/ZLiveTvEffect.cpp
+++ b/src/Effects/UI/ZLiveTvEffect.cpp
@@ -74,7 +74,6 @@ void ZLiveTvEffect::OnDrawDebugUI()
 
 void ZLiveTvEffect::Start()
 {
-
     auto s_pVideoResource = Math::SelectRandomElement(m_aVideoResources);
     if (s_pVideoResource && s_pVideoResource->IsAvailable())
     {

--- a/src/Effects/UI/ZLiveTvEffect.h
+++ b/src/Effects/UI/ZLiveTvEffect.h
@@ -1,0 +1,30 @@
+#include "Effects/Base/Companion/ZHUDImageVideoViewEffectBase.h"
+
+#include "Helpers/ZResourceProvider.h"
+
+#include <vector>
+
+class ZLiveTvEffect : public ZHUDImageVideoViewEffectBase
+{
+  public:
+    void LoadResources() override;
+    void OnEnterScene() override;
+    void OnClearScene() override;
+    bool Available() const override;
+    bool IsCompatibleWith(const IChaosEffect* p_pOther) const override;
+
+    void OnDrawDebugUI() override;
+
+    void Start();
+    void Stop();
+
+  private:
+    SVector2 m_vSize = SVector2(30.f, 30.f);
+    SVector2 m_vPositionMin = SVector2(-370.f, -200.f);
+    SVector2 m_vPositionMax = SVector2(950.f, 530.f);
+
+  private:
+    std::vector<std::shared_ptr<ZResourceProvider>> m_aVideoResources;
+
+    void PlayVideo(const ZRuntimeResourceID& p_ridVideo);
+};

--- a/src/Effects/UI/ZLiveTvEffect.h
+++ b/src/Effects/UI/ZLiveTvEffect.h
@@ -8,10 +8,8 @@ class ZLiveTvEffect : public ZHUDImageVideoViewEffectBase
 {
   public:
     void LoadResources() override;
-    void OnEnterScene() override;
     void OnClearScene() override;
     bool Available() const override;
-    bool IsCompatibleWith(const IChaosEffect* p_pOther) const override;
 
     void OnDrawDebugUI() override;
 
@@ -25,6 +23,7 @@ class ZLiveTvEffect : public ZHUDImageVideoViewEffectBase
 
   private:
     std::vector<std::shared_ptr<ZResourceProvider>> m_aVideoResources;
+    std::vector<SImageVideoViewEntityBinding> m_aActiveVideoViews;
 
     void PlayVideo(const ZRuntimeResourceID& p_ridVideo);
 };

--- a/src/Effects/UI/ZLiveTvEffect.h
+++ b/src/Effects/UI/ZLiveTvEffect.h
@@ -1,3 +1,4 @@
+#pragma once
 #include "Effects/Base/Companion/ZHUDImageVideoViewEffectBase.h"
 
 #include "Helpers/ZResourceProvider.h"

--- a/src/Effects/UI/ZLiveTvEffect.h
+++ b/src/Effects/UI/ZLiveTvEffect.h
@@ -16,6 +16,11 @@ class ZLiveTvEffect : public ZHUDImageVideoViewEffectBase
     void Start();
     void Stop();
 
+    std::string GetDisplayName(const bool p_bVoting) const override
+    {
+        return "On-Demand TV";
+    }
+
   private:
     SVector2 m_vSize = SVector2(30.f, 30.f);
     SVector2 m_vPositionMin = SVector2(-370.f, -200.f);

--- a/src/Effects/UI/ZRotateUIRootEffect.cpp
+++ b/src/Effects/UI/ZRotateUIRootEffect.cpp
@@ -18,8 +18,6 @@
 
 #define TAG "[ZRotateUIRootEffect] "
 
-constexpr float32 c_fPI = 3.14159f;
-
 void ZRotateUIRootEffect::OnEngineInitialized()
 {
     const ZMemberDelegate<ZRotateUIRootEffect, void(const SGameUpdateEvent&)> s_Delegate(this, &ZRotateUIRootEffect::OnFrameUpdateAlways);

--- a/src/Effects/UI/ZRotateUIRootEffect.cpp
+++ b/src/Effects/UI/ZRotateUIRootEffect.cpp
@@ -1,0 +1,97 @@
+#include "ZRotateUIRootEffect.h"
+
+#include <imgui.h>
+#include <Logging.h>
+
+#include <cmath>
+
+#include <Glacier/ZGameLoopManager.h>
+#include <Glacier/SGameUpdateEvent.h>
+
+#include "Registry.h"
+#include "Helpers/EntityUtils.h"
+
+#include "Entity/EntityIds.h"
+#include "Entity/Bindings/SZUIControlEntityBinding.h"
+
+#include "Effects/UI/ZNoHUDEffect.h"
+
+#define TAG "[ZRotateUIRootEffect] "
+
+constexpr float32 c_fPI = 3.14159f;
+
+void ZRotateUIRootEffect::OnEngineInitialized()
+{
+    const ZMemberDelegate<ZRotateUIRootEffect, void(const SGameUpdateEvent&)> s_Delegate(this, &ZRotateUIRootEffect::OnFrameUpdateAlways);
+    Globals::GameLoopManager->RegisterFrameUpdate(s_Delegate, 1, EUpdateMode::eUpdateAlways);
+}
+
+void ZRotateUIRootEffect::OnModUnload()
+{
+    m_bActive = false;
+
+    const ZMemberDelegate<ZRotateUIRootEffect, void(const SGameUpdateEvent&)> s_Delegate(this, &ZRotateUIRootEffect::OnFrameUpdateAlways);
+    Globals::GameLoopManager->UnregisterFrameUpdate(s_Delegate, 1, EUpdateMode::eUpdateAlways);
+}
+
+void ZRotateUIRootEffect::OnEnterScene()
+{
+    m_rUIRoot = Utils::ZEntityFinder()
+                    .EntityID(EntityId::HM3::GameEssentials::MasterRoot)
+                    .FindFirst();
+    m_bActive = false;
+}
+
+void ZRotateUIRootEffect::OnClearScene()
+{
+    m_rUIRoot = {};
+    m_bActive = false;
+}
+
+bool ZRotateUIRootEffect::Available() const
+{
+    return IChaosEffect::Available()
+           && m_rUIRoot;
+}
+
+void ZRotateUIRootEffect::OnDrawDebugUI()
+{
+    ImGui::DragFloat3("Rotation Rate", &m_vRotationRate.x);
+    ImGui::TextUnformatted(fmt::format("Elapsed Time: {:.2f}s", m_fTimeElapsed).c_str());
+}
+
+void ZRotateUIRootEffect::Start()
+{
+    m_bActive = true;
+    m_fTimeElapsed = 0.0f;
+}
+
+void ZRotateUIRootEffect::Stop()
+{
+    m_bActive = false;
+
+    auto s_UIBinding = SZUIControlEntityBinding(m_rUIRoot);
+    s_UIBinding.m_vRotation = SVector3(0.f, 0.f, 0.f);
+}
+
+void ZRotateUIRootEffect::OnFrameUpdateAlways(const SGameUpdateEvent& p_UpdateEvent)
+{
+    if (!m_bActive || !m_rUIRoot)
+    {
+        return;
+    }
+
+    m_fTimeElapsed += static_cast<float32>(p_UpdateEvent.m_RealTimeDelta.ToSeconds());
+
+    const auto s_vRotation = SVector3(
+        90.f * std::sin(m_vRotationRate.x * m_fTimeElapsed),
+        90.f * std::sin(m_vRotationRate.y * m_fTimeElapsed),
+        90.f * std::sin(m_vRotationRate.z * m_fTimeElapsed)
+    );
+
+    auto s_UIBinding = SZUIControlEntityBinding(m_rUIRoot);
+    s_UIBinding.m_vRotation = s_vRotation;
+}
+
+REGISTER_CHAOS_EFFECT_PARAM(swing, ZRotateUIRootEffect, "swing", "HUD Swing", SVector3(1.f, 0.f, 0.f));
+REGISTER_CHAOS_EFFECT_PARAM(chaotic, ZRotateUIRootEffect, "chaotic", "UI go Wheee!", SVector3(1.f, 0.8f, 0.f));

--- a/src/Effects/UI/ZRotateUIRootEffect.cpp
+++ b/src/Effects/UI/ZRotateUIRootEffect.cpp
@@ -9,6 +9,7 @@
 #include <Glacier/SGameUpdateEvent.h>
 
 #include "Registry.h"
+#include "Helpers/Utils.h"
 #include "Helpers/EntityUtils.h"
 
 #include "Entity/EntityIds.h"
@@ -50,6 +51,17 @@ bool ZRotateUIRootEffect::Available() const
 {
     return IChaosEffect::Available()
            && m_rUIRoot;
+}
+
+bool ZRotateUIRootEffect::IsCompatibleWith(const IChaosEffect* p_Other) const
+{
+    return IChaosEffect::IsCompatibleWith(p_Other)
+
+           // doesn't work when no HUD
+           && !Utils::IsInstanceOf<ZNoHUDEffect>(p_Other)
+
+           // two instances of this effect would conflict with each other
+           && !Utils::IsInstanceOf<ZRotateUIRootEffect>(p_Other);
 }
 
 void ZRotateUIRootEffect::OnDrawDebugUI()

--- a/src/Effects/UI/ZRotateUIRootEffect.h
+++ b/src/Effects/UI/ZRotateUIRootEffect.h
@@ -18,6 +18,8 @@ class ZRotateUIRootEffect : public IChaosEffect
     void OnEnterScene() override;
     void OnClearScene() override;
     bool Available() const override;
+    bool IsCompatibleWith(const IChaosEffect* p_Other) const override;
+
     void OnDrawDebugUI() override;
 
     void Start() override;

--- a/src/Effects/UI/ZRotateUIRootEffect.h
+++ b/src/Effects/UI/ZRotateUIRootEffect.h
@@ -1,0 +1,52 @@
+#pragma once
+#include "IChaosEffect.h"
+
+#include <Glacier/ZEntity.h>
+#include <Glacier/ZMath.h>
+
+class ZRotateUIRootEffect : public IChaosEffect
+{
+  public:
+    ZRotateUIRootEffect(const std::string p_sNameSuffix, const std::string p_sDisplayName, const SVector3 p_vRotationRate) : m_sNameSuffix(p_sNameSuffix),
+                                                                                                                             m_sDisplayName(p_sDisplayName),
+                                                                                                                             m_vRotationRate(p_vRotationRate)
+    {
+    }
+
+    void OnEngineInitialized() override;
+    void OnModUnload() override;
+    void OnEnterScene() override;
+    void OnClearScene() override;
+    bool Available() const override;
+    void OnDrawDebugUI() override;
+
+    void Start() override;
+    void Stop() override;
+
+    std::string GetName() const override
+    {
+        return IChaosEffect::GetName() + "_" + m_sNameSuffix;
+    }
+
+    std::string GetDisplayName(const bool p_bVoting) const override
+    {
+        return m_sDisplayName;
+    }
+
+    EDuration GetDuration() const override
+    {
+        return EDuration::Short;
+    }
+
+  private:
+    std::string m_sNameSuffix;
+    std::string m_sDisplayName;
+    SVector3 m_vRotationRate;
+
+  private:
+    bool m_bActive = false;
+    float32 m_fTimeElapsed = 0.0f;
+    ZEntityRef m_rUIRoot;
+
+    void OnFrameUpdateAlways(const SGameUpdateEvent& p_UpdateEvent);
+};

--- a/src/Effects/UI/ZShakyReticleEffect.cpp
+++ b/src/Effects/UI/ZShakyReticleEffect.cpp
@@ -1,0 +1,95 @@
+#include "ZShakyReticleEffect.h"
+
+#include <imgui.h>
+#include <Logging.h>
+
+#include <Glacier/SGameUpdateEvent.h>
+
+#include "Registry.h"
+#include "ZConfigurationAccessor.h"
+#include "Helpers/Math.h"
+#include "Helpers/Utils.h"
+#include "Helpers/EntityUtils.h"
+
+#include "Entity/EntityIds.h"
+#include "Entity/Bindings/SZUIControlEntityBinding.h"
+
+#include "Effects/UI/ZNoHUDEffect.h"
+
+#define TAG "[ZShakyReticleEffect] "
+
+void ZShakyReticleEffect::OnEnterScene()
+{
+    m_rHUDReticle = Utils::ZEntityFinder()
+                        .EntityID(EntityId::HM3::GameEssentials::HUDReticle)
+                        .FindFirst();
+    m_bActive = false;
+}
+
+void ZShakyReticleEffect::OnClearScene()
+{
+    m_rHUDReticle = {};
+    m_bActive = false;
+}
+
+bool ZShakyReticleEffect::Available() const
+{
+    return IChaosEffect::Available()
+           && m_rHUDReticle;
+}
+
+bool ZShakyReticleEffect::IsCompatibleWith(const IChaosEffect* p_pOther) const
+{
+    return IChaosEffect::IsCompatibleWith(p_pOther)
+           // joke doesn't really work when HUD is not visible...
+           && !Utils::IsInstanceOf<ZNoHUDEffect>(p_pOther);
+}
+
+void ZShakyReticleEffect::OnDrawDebugUI()
+{
+    ImGui::TextUnformatted(fmt::format("Position: {}, {}", m_vPosition.x, m_vPosition.y).c_str());
+
+    ImGui::DragFloat("Amplitude", &m_fShakeAmplitude, .1f);
+    ImGui::DragFloat("Max Deflection", &m_fMaxDeflection, .5f);
+}
+
+void ZShakyReticleEffect::Start()
+{
+    m_vPosition = SVector2(0.f, 0.f);
+    m_bActive = true;
+}
+
+void ZShakyReticleEffect::Stop()
+{
+    m_bActive = false;
+
+    auto s_Binding = SZUIControlEntityBinding(m_rHUDReticle);
+    s_Binding.m_vPositionOffset = SVector3(0.f, 0.f, 0.f); // default from gameessentials TEMP
+}
+
+void ZShakyReticleEffect::OnFrameUpdate(const SGameUpdateEvent& p_UpdateEvent, const float32 p_fEffectTimeRemaining)
+{
+    if (!m_bActive || !m_rHUDReticle)
+    {
+        return;
+    }
+
+    auto s_Binding = SZUIControlEntityBinding(m_rHUDReticle);
+    if (!s_Binding)
+    {
+        return;
+    }
+
+    // add random deflection
+    m_vPosition.x += Math::GetRandomNumber<float32>(-m_fShakeAmplitude, m_fShakeAmplitude);
+    m_vPosition.y += Math::GetRandomNumber<float32>(-m_fShakeAmplitude, m_fShakeAmplitude);
+
+    // limit deflection
+    m_vPosition.x = Math::Clamp(m_vPosition.x, -m_fMaxDeflection, m_fMaxDeflection);
+    m_vPosition.y = Math::Clamp(m_vPosition.y, -m_fMaxDeflection, m_fMaxDeflection);
+
+    // set position ignoring z
+    s_Binding.m_vPositionOffset = SVector3(m_vPosition.x, m_vPosition.y, 0.f);
+}
+
+REGISTER_CHAOS_EFFECT(ZShakyReticleEffect);

--- a/src/Effects/UI/ZShakyReticleEffect.h
+++ b/src/Effects/UI/ZShakyReticleEffect.h
@@ -1,0 +1,40 @@
+#pragma once
+#include "IChaosEffect.h"
+
+#include <Glacier/ZEntity.h>
+#include <Glacier/ZMath.h>
+
+class ZShakyReticleEffect : public IChaosEffect
+{
+  public:
+    void OnEnterScene() override;
+    void OnClearScene() override;
+    bool Available() const override;
+    bool IsCompatibleWith(const IChaosEffect* p_pOther) const override;
+
+    void OnDrawDebugUI() override;
+
+    void Start() override;
+    void Stop() override;
+    void OnFrameUpdate(const SGameUpdateEvent& p_UpdateEvent, const float32 p_fEffectTimeRemaining) override;
+
+    std::string GetDisplayName(const bool p_bVoting) const override
+    {
+        return "Shaky Hands";
+    }
+
+    EDuration GetDuration() const override
+    {
+        return EDuration::Short;
+    }
+
+  private:
+    float32 m_fShakeAmplitude = 12.f;
+    float32 m_fMaxDeflection = 150.f;
+
+  private:
+    bool m_bActive = false;
+    ZEntityRef m_rHUDReticle;
+
+    SVector2 m_vPosition = SVector2(0.f, 0.f);
+};

--- a/src/Entity/Bindings/SGenericModalDialogTwoButtonsEntityBinding.h
+++ b/src/Entity/Bindings/SGenericModalDialogTwoButtonsEntityBinding.h
@@ -1,0 +1,15 @@
+#pragma once
+#include "Entity/Bindings/EntityBinding.h"
+
+// [assembly:/_pro/design/tutorialsupport.template?/tutorial_ui_genericmodaldialogtwobuttons.entitytemplate].pc_entitytype
+struct SGenericModalDialogTwoButtonsEntityBinding : public SEntityBinding
+{
+    using SEntityBinding::SEntityBinding;
+
+    PROPERTY(ZRuntimeResourceID, m_pTitle);    // Dialog title LINE resource
+    PROPERTY(ZRuntimeResourceID, m_pText);     // Dialog text LINE resource
+    PROPERTY(ZRuntimeResourceID, PromptText);  // First button text LINE resource
+    PROPERTY(ZRuntimeResourceID, PromptText2); // Second button text LINE resource
+
+    INPUT_PIN(Show); // Show the dialog. after showing, there will be no way to check which button the user pressed (feedback handled via output pins, which binding does not support rn)
+};

--- a/src/Entity/Bindings/SImageVideoViewEntityBinding.h
+++ b/src/Entity/Bindings/SImageVideoViewEntityBinding.h
@@ -1,0 +1,33 @@
+#pragma once
+#include "Entity/Bindings/EntityBinding.h"
+
+#include <Glacier/ZMath.h>
+
+// [assembly:/_pro/scenes/bricks/gameessentialsbase.brick].pc_entitytype
+// entity "ChaosMod_HUD_IV" added by companion mod version 1.4.0 via patch cm_hud_image_and_video_view.entity.patch.json
+// NOTE: position and size are shared by both image and video, but behave diffently. use debug tool to ensure proper positioning.
+struct SImageVideoViewEntityBinding : public SEntityBinding
+{
+    using SEntityBinding::SEntityBinding;
+
+    // position of the view inside the (full-screen) container. Z may be set, but is recommended not to.
+    // for image: position of the center; x from -960~960, y from -540~540
+    // for video: position of bottom right corner; x from -960~960, y from -540~540
+    PROPERTY(SVector3, m_vPositionOffset);
+
+    // size of the view.
+    // for image: % scale of the original image, from 0~1.
+    // for video: tbh, no idea about units, just test via debug tool.
+    PROPERTY(SVector2, m_vSize);
+
+    PROPERTY(SVector3, m_vRotation);          // rotation of the views.
+    PROPERTY(bool, m_bImageIsVisible);        // is the image view visible? note that image and video overlap.
+    PROPERTY(bool, m_bVideoIsVisible);        // is the video view visible? note that image and video overlap.
+    PROPERTY(ZRuntimeResourceID, m_ridImage); // resource id displayed in the image view. must be loaded beforehand. supports .pc_gfx
+    PROPERTY(ZRuntimeResourceID, m_ridVideo); // resource id of the video. must be loaded beforehand. supports .pc_gfxv
+    //PROPERTY(bool, m_bVideoVolumeOn);         // is the video sound on (true) or muted (false)?
+    PROPERTY(bool, m_bVideoLoop);             // should the video loop?
+
+    INPUT_PIN(PlayVideo); // start playing the video. before playback starts, the video is not shown.
+    INPUT_PIN(StopVideo); // stop playing the video. the video will be invisible after this, until PlayVideo is called again.
+};

--- a/src/Entity/Bindings/SImageVideoViewEntityBinding.h
+++ b/src/Entity/Bindings/SImageVideoViewEntityBinding.h
@@ -25,7 +25,6 @@ struct SImageVideoViewEntityBinding : public SEntityBinding
     PROPERTY(bool, m_bVideoIsVisible);        // is the video view visible? note that image and video overlap.
     PROPERTY(ZRuntimeResourceID, m_ridImage); // resource id displayed in the image view. must be loaded beforehand. supports .pc_gfx
     PROPERTY(ZRuntimeResourceID, m_ridVideo); // resource id of the video. must be loaded beforehand. supports .pc_gfxv
-    //PROPERTY(bool, m_bVideoVolumeOn);         // is the video sound on (true) or muted (false)?
     PROPERTY(bool, m_bVideoLoop);             // should the video loop?
 
     INPUT_PIN(PlayVideo); // start playing the video. before playback starts, the video is not shown.

--- a/src/Entity/Bindings/SImageVideoViewEntityBinding.h
+++ b/src/Entity/Bindings/SImageVideoViewEntityBinding.h
@@ -5,7 +5,7 @@
 
 // [assembly:/_pro/scenes/bricks/gameessentialsbase.brick].pc_entitytype
 // entity "ChaosMod_HUD_IV" added by companion mod version 1.4.0 via patch cm_hud_image_and_video_view.entity.patch.json
-// NOTE: position and size are shared by both image and video, but behave diffently. use debug tool to ensure proper positioning.
+// NOTE: position and size are shared by both image and video, but behave differently. use debug tool to ensure proper positioning.
 struct SImageVideoViewEntityBinding : public SEntityBinding
 {
     using SEntityBinding::SEntityBinding;

--- a/src/Entity/Bindings/SZUIControlEntityBinding.h
+++ b/src/Entity/Bindings/SZUIControlEntityBinding.h
@@ -26,7 +26,6 @@ struct SZUIControlEntityBinding : public SEntityBinding
     PROPERTY(ZEntityRef, m_pLayoutEntity);
     PROPERTY(bool, m_bIsVisible);
 
-
     // [modules:/zuicontrollayoutlegacyaspect.class].pc_entitytype
     PROPERTY(bool, m_bIsLegacyLayoutActive);
     PROPERTY(ZUIControlLayoutLegacyAspect_EAlignmentType, m_eAlignmentType);

--- a/src/Entity/Bindings/SZUIControlEntityBinding.h
+++ b/src/Entity/Bindings/SZUIControlEntityBinding.h
@@ -1,0 +1,35 @@
+#pragma once
+#include "Entity/Bindings/EntityBinding.h"
+
+#include <Glacier/Enums.h>
+#include <Glacier/ZMath.h>
+
+// [modules:/zuicontrolentity.class].pc_entitytype
+// + [modules:/zuicontrollayoutlegacyaspect.class].pc_entitytype
+// also applicable to many other UI controls, e.g. [assembly:/templates/ui/controls/basiccontrols.template?/container.entitytemplate].pc_entitytype and most .uic
+struct SZUIControlEntityBinding : public SEntityBinding
+{
+    using SEntityBinding::SEntityBinding;
+
+    // [modules:/zuicontrolentity.class].pc_entitytype
+    PROPERTY(ZUIControlEntity_EAlignment, m_eAlignment);
+    PROPERTY(SVector2, m_vAlignment);
+    PROPERTY(SVector3, m_vPositionOffset);
+    PROPERTY(SVector3, m_vRotation);
+    PROPERTY(float32, m_fAlpha); // 0 - 100
+    PROPERTY(SVector2, m_vLayoutSize);
+    PROPERTY(bool, m_bUseContentSize);
+    PROPERTY(ZUIControlEntity_EScaleMode, m_eScaleMode);
+    PROPERTY(SVector2, m_vScaleManual);
+    PROPERTY(SVector2, m_vScaleResolutionBase);
+    PROPERTY(bool, m_bIsContainer);
+    PROPERTY(ZEntityRef, m_pLayoutEntity);
+    PROPERTY(bool, m_bIsVisible);
+
+
+    // [modules:/zuicontrollayoutlegacyaspect.class].pc_entitytype
+    PROPERTY(bool, m_bIsLegacyLayoutActive);
+    PROPERTY(ZUIControlLayoutLegacyAspect_EAlignmentType, m_eAlignmentType);
+    PROPERTY(ZUIControlLayoutLegacyAspect_ELayoutMode, m_eSizeMode);
+    PROPERTY(SVector2, m_vSize);
+};

--- a/src/Entity/EntityIds.h
+++ b/src/Entity/EntityIds.h
@@ -92,6 +92,16 @@ namespace EntityId
             /// FX_Fireworks_LaunchPad > Fireworks > TimerSimple03
             constexpr entityId_t TimerSimple03 = 0x3ac42cc89a95ba81;
         } // namespace FXFireworksLaunchpad
+
+        /// [assembly:/templates/ui/mapsetup.template?/minimap.entitytemplate].pc_entitytype
+        namespace Minimap
+        {
+            /// Minimap > Container
+            constexpr entityId_t Container = 0x2ffb0f5ca9c6a9cc;
+
+            /// Minimap > hud_StatusMarkers
+            constexpr entityId_t HUDStatusMarkers = 0xe528fc056fd72ddd;
+        } // namespace Minimap
     } // namespace HM3
 
     /// Entities defined in ZHMChaosMod SMF Companion Mod

--- a/src/Entity/EntityIds.h
+++ b/src/Entity/EntityIds.h
@@ -138,5 +138,12 @@ namespace EntityId
                 constexpr entityId_t FlamingoDance = 0xcafecaa57d32d0a0;
             } // namespace ActLibrary
         } // namespace NPCActor
+
+        /// [assembly:/_pro/scenes/bricks/gameessentialsbase.brick].pc_entitytype
+        namespace GameEssentials
+        {
+            /// Scene > [GameEssentials.brick] > ChaosMod_HUD_IV
+            constexpr entityId_t HUDImageVideoView = 0xcafe9dc9c6868fa4;
+        } // namespace GameEssentials
     } // namespace CompanionMod
 } // namespace EntityId

--- a/src/Entity/EntityIds.h
+++ b/src/Entity/EntityIds.h
@@ -138,12 +138,5 @@ namespace EntityId
                 constexpr entityId_t FlamingoDance = 0xcafecaa57d32d0a0;
             } // namespace ActLibrary
         } // namespace NPCActor
-
-        /// [assembly:/_pro/scenes/bricks/gameessentialsbase.brick].pc_entitytype
-        namespace GameEssentials
-        {
-            /// Scene > [GameEssentials.brick] > ChaosMod_HUD_IV
-            constexpr entityId_t HUDImageVideoView = 0xcafe9dc9c6868fa4;
-        } // namespace GameEssentials
     } // namespace CompanionMod
 } // namespace EntityId

--- a/src/Entity/EntityIds.h
+++ b/src/Entity/EntityIds.h
@@ -138,5 +138,13 @@ namespace EntityId
                 constexpr entityId_t FlamingoDance = 0xcafecaa57d32d0a0;
             } // namespace ActLibrary
         } // namespace NPCActor
+
+        /// [assembly:/_pro/scenes/bricks/gameessentialsbase.brick].pc_entitytype
+        namespace GameEssentials
+        {
+            /// fake_disconnect_dialog.entity.patch
+            /// Scene > [GameEssentials.brick] > ChaosMod > UI_Modal_Disconnected_FAKE
+            constexpr entityId_t UIModalDisconnectedFake = 0xcafe56ad817d7725;
+        } // namespace GameEssentials
     } // namespace CompanionMod
 } // namespace EntityId

--- a/src/Entity/EntityIds.h
+++ b/src/Entity/EntityIds.h
@@ -21,6 +21,9 @@ namespace EntityId
 
             /// Scene > [GameEssentials.brick] > UI > IngameMenu > MapMenu > InGameMapSetup > Minimap
             constexpr entityId_t Minimap = 0xccda0a613b5d88cb;
+
+            /// Scene > [GameEssentials.brick] > UI > HUD > hud_Reticle
+            constexpr entityId_t HUDReticle = 0x497de7558620e74b;
         } // namespace GameEssentials
 
         /// [assembly:/templates/gameplay/ai2/actors.template?/npcactor.entitytemplate].pc_entitytype

--- a/src/Helpers/ZResourceProvider.h
+++ b/src/Helpers/ZResourceProvider.h
@@ -25,6 +25,11 @@ class ZResourceProvider
         return std::make_unique<ZResourceProvider>(ResPath.Value, ResId<ResPath>);
     }
 
+    static std::unique_ptr<ZResourceProvider> Create(const std::string& p_sResourcePath)
+    {
+        return std::make_unique<ZResourceProvider>(p_sResourcePath, ZRuntimeResourceID::FromString(p_sResourcePath));
+    }
+
     ZResourceProvider(const std::string p_sResourcePath, const ZRuntimeResourceID p_ResourceId);
     ~ZResourceProvider();
 


### PR DESCRIPTION
<!-- 
Please provide a brief summary of the changes in this pull request. 
Include any relevant context, screenshots, notes.
If this PR is related to an issue (active or not), please reference it here.
-->

Effects added:

- "Maximap"
- "HUD Swing"
- "UI go Wheee!"
- "Bouncy Minimap"
- "Shaky Hands" (shaky Reticle)
- "On-Demand TV" (ZLiveTvEffect) + ZHUDImageVideoViewEffectBase helper
- "Aim Assist" (ZCustomReticleEffect) with multiple variations
- "Unstable Internet" (ZFakeConnectionLostEffect)

some (not all!) of these effects depend on https://github.com/shadow578/ZHMChaosModCompanion/pull/2


## Checklist

- [x] I consent to automatic PR review by GitHub Copilot. <!-- This consent is optional; uncheck to opt out for this PR. -->
- [ ] I added attributon (if applicable)
- [ ] I updated documentation (if applicable)
